### PR TITLE
Add https miuse detection plugin

### DIFF
--- a/sireum-amandroid-run/src/main/scala/org/sireum/amandroid/run/security/HttpsMisuse_run.scala
+++ b/sireum-amandroid-run/src/main/scala/org/sireum/amandroid/run/security/HttpsMisuse_run.scala
@@ -1,0 +1,106 @@
+/*
+Copyright (c) 2013-2014 Fengguo Wei & Sankardas Roy, Kansas State University. Qidan He.        
+All rights reserved. This program and the accompanying materials      
+are made available under the terms of the Eclipse Public License v1.0 
+which accompanies this distribution, and is available at              
+http://www.eclipse.org/legal/epl-v10.html                             
+*/
+package org.sireum.amandroid.run.security
+
+import org.sireum.amandroid.security._
+import org.sireum.jawa.MessageCenter._
+import org.sireum.util.FileUtil
+import org.sireum.amandroid.security.apiMisuse.InterestingApiCollector
+import org.sireum.amandroid.util.AndroidLibraryAPISummary
+import org.sireum.amandroid.AppCenter
+import org.sireum.amandroid.security.apiMisuse.HttpsMisuse
+import org.sireum.jawa.alir.interProcedural.InterProceduralDataFlowGraph
+import org.sireum.amandroid.alir.reachingFactsAnalysis.AndroidReachingFactsAnalysisConfig
+import org.sireum.jawa.util.Timer
+import org.sireum.jawa.util.IgnoreException
+
+/**
+ * @author <a href="mailto:i@flanker017.me">Qidan He</a>
+ */
+object HttpsMisuse_run {
+  private final val TITLE = "HttpsMisuse_run"
+  
+  object HttpsMisuseCounter {
+    var total = 0
+    var oversize = 0
+    var haveresult = 0
+    
+    override def toString : String = "total: " + total + ", oversize: " + oversize + ", haveResult: " + haveresult
+  }
+  
+  private class HTTPSMisuseListener extends AmandroidSocketListener {
+    def onPreAnalysis: Unit = {
+      HttpsMisuseCounter.total += 1
+    }
+
+    def entryPointFilter(eps: Set[org.sireum.jawa.JawaProcedure]): Set[org.sireum.jawa.JawaProcedure] = {
+      eps
+    }
+
+    def onTimeout : Unit = {}
+
+    def onAnalysisSuccess : Unit = {
+      HttpsMisuseCounter.haveresult += 1
+    }
+
+    def onPostAnalysis: Unit = {
+      msg_critical(TITLE, HttpsMisuseCounter.toString)
+    }
+    
+    def onException(e : Exception) : Unit = {
+      e match{
+        case ie : IgnoreException => System.err.println("Ignored!")
+        case a => 
+          e.printStackTrace()
+      }
+    }
+  }
+  
+  def main(args: Array[String]): Unit = {
+    if(args.size != 2){
+      System.err.print("Usage: source_path output_path")
+      return
+    }
+    
+    val socket = new AmandroidSocket
+    socket.preProcess
+    
+    AndroidReachingFactsAnalysisConfig.k_context = 1
+    AndroidReachingFactsAnalysisConfig.resolve_icc = false
+    AndroidReachingFactsAnalysisConfig.resolve_static_init = true;
+    
+    val sourcePath = args(0)
+    val outputPath = args(1)
+    
+    val files = FileUtil.listFiles(FileUtil.toUri(sourcePath), ".apk", true).toSet
+    
+    files.foreach{
+      file =>
+        try{
+          msg_critical(TITLE, "####" + file + "#####")
+          AndroidReachingFactsAnalysisConfig.timerOpt = Some(new Timer(5))
+          val app_info = new InterestingApiCollector(file)
+          socket.loadApk(file, outputPath, AndroidLibraryAPISummary, app_info)
+          socket.plugListener(new HTTPSMisuseListener)
+          socket.runWithoutDDA(false, true)
+           
+           val idfgs = AppCenter.getInterproceduralReachingFactsAnalysisResults
+            idfgs.foreach{
+              case (rec, InterProceduralDataFlowGraph(icfg, irfaResult)) =>
+                HttpsMisuse(new InterProceduralDataFlowGraph(icfg, irfaResult))
+            }
+        } catch {
+          case e : Throwable =>
+            e.printStackTrace()
+        } finally {
+          socket.cleanEnv
+        }
+    }
+  }
+
+}

--- a/sireum-amandroid-security/src/main/scala/org/sireum/amandroid/security/apiMisuse/HttpsMisuse.scala
+++ b/sireum-amandroid-security/src/main/scala/org/sireum/amandroid/security/apiMisuse/HttpsMisuse.scala
@@ -1,0 +1,177 @@
+/*
+Copyright (c) 2013-2014 Fengguo Wei & Sankardas Roy, Kansas State University. Qidan He.        
+All rights reserved. This program and the accompanying materials      
+are made available under the terms of the Eclipse Public License v1.0 
+which accompanies this distribution, and is available at              
+http://www.eclipse.org/legal/epl-v10.html                             
+*/
+package org.sireum.amandroid.security.apiMisuse
+
+import org.sireum.jawa.MessageCenter
+import org.sireum.util.FileUtil
+import org.sireum.amandroid.alir.reachingFactsAnalysis.AndroidReachingFactsAnalysisConfig
+import org.sireum.amandroid.security.AmandroidSocket
+import org.sireum.jawa.Center
+import org.sireum.amandroid.AndroidConstants
+import org.sireum.amandroid.alir.reachingFactsAnalysis.AndroidReachingFactsAnalysis
+import org.sireum.amandroid.AppCenter
+import org.sireum.jawa.ClassLoadManager
+import org.sireum.jawa.alir.interProcedural.InterProceduralDataFlowGraph
+import org.sireum.jawa.alir.interProcedural.InterProceduralMonotoneDataFlowAnalysisResult
+import org.sireum.jawa.alir.controlFlowGraph.CGNode
+import org.sireum.jawa.alir.controlFlowGraph.CGCallNode
+import org.sireum.util.MSet
+import org.sireum.util.MMap
+import org.sireum.jawa.alir.reachingFactsAnalysis.RFAFact
+import org.sireum.pilar.ast.NameExp
+import org.sireum.pilar.ast.TupleExp
+import org.sireum.jawa.alir.reachingFactsAnalysis.RFAConcreteStringInstance
+import org.sireum.pilar.ast.CallJump
+import org.sireum.jawa.JawaProcedure
+import org.sireum.pilar.ast.JumpLocation
+import org.sireum.util.MList
+import org.sireum.jawa.alir.reachingFactsAnalysis.VarSlot
+import org.sireum.jawa.alir.interProcedural.InterProceduralDataFlowGraph
+import org.sireum.jawa.MessageCenter._
+import org.sireum.util._
+import org.sireum.jawa.alir.reachingFactsAnalysis.RFAFact
+import org.sireum.jawa.alir.controlFlowGraph._
+import org.sireum.pilar.ast._
+import org.sireum.jawa.Center
+import org.sireum.jawa.alir.interProcedural.InterProceduralMonotoneDataFlowAnalysisResult
+import org.sireum.jawa.alir.reachingFactsAnalysis.VarSlot
+import org.sireum.jawa.alir.reachingFactsAnalysis.RFAConcreteStringInstance
+import org.sireum.jawa.JawaProcedure
+import org.sireum.amandroid.util.AndroidLibraryAPISummary
+import org.sireum.amandroid.security.AmandroidSocketListener
+import org.sireum.jawa.util.IgnoreException
+import org.sireum.jawa.util.Timer
+import org.sireum.jawa.alir.reachability.ReachabilityAnalysis
+/*
+ * @author <a href="mailto:i@flanker017.me">Qidan He</a>
+ */
+object HttpsMisuse {
+  private final val API_SIG = "Lorg/apache/http/conn/ssl/SSLSocketFactory;.setHostnameVerifier:(Lorg/apache/http/conn/ssl/X509HostnameVerifier;)V"
+  private final val VUL_PARAM = "@@org.apache.http.conn.ssl.SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER"
+  
+  def apply(idfg : InterProceduralDataFlowGraph) : Unit
+    = build(idfg)
+    
+  def build(idfg : InterProceduralDataFlowGraph) : Unit = {
+    val icfg = idfg.icfg
+    val summary = idfg.summary
+    val nodeMap : MMap[String, MSet[CGCallNode]] = mmapEmpty
+    val callmap = icfg.getCallMap
+    icfg.nodes.foreach{
+      node =>
+        val result = getHTTPSNode(node)
+        result.foreach{
+          r =>
+            nodeMap.getOrElseUpdate(r._1, msetEmpty) += r._2
+        }
+    }
+    val rule1Res = VerifierCheck(nodeMap, summary)
+    rule1Res.foreach{
+      case (n, b) =>
+        if(!b){
+          println(n.context + " using wrong ssl hostname configuration!")
+        }
+    }
+  }
+  
+  /**
+   * detect constant propagation on ALLOW_ALLHOSTNAME_VERIFIER
+   * which is a common api miuse in many android apps.
+   */
+  def VerifierCheck(nodeMap : MMap[String, MSet[CGCallNode]], summary : InterProceduralMonotoneDataFlowAnalysisResult[RFAFact]): Map[CGCallNode, Boolean] = {
+    var result : Map[CGCallNode, Boolean] = Map()
+    val nodes : MSet[CGCallNode] = msetEmpty
+    nodeMap.foreach{
+      case (sig, ns) =>
+        if(sig.equals(API_SIG))
+          nodes ++= ns
+    }
+    nodes.foreach{
+      node =>
+        result += (node -> true)
+        val rfaFacts = summary.entrySet(node)//dataflowfact at this node
+        
+        val loc = Center.getProcedureWithoutFailing(node.getOwner).getProcedureBody.location(node.getLocIndex)
+        val argNames : MList[String] = mlistEmpty
+        loc match{
+          case jumploc : JumpLocation =>
+            jumploc.jump match {
+              case t : CallJump if t.jump.isEmpty =>
+                t.callExp.arg match {
+                  case te : TupleExp =>
+                    val exps = te.exps
+                    for(i <- 0 to (exps.size-1)) {
+                      val varName = exps(i) match{
+                        case ne : NameExp => ne.name.name
+                        case a => a.toString()
+                      }
+                      argNames += varName
+                    }
+                  case _ =>
+                }
+              case _ =>
+            }
+          case _ =>
+        }
+        require(argNames.isDefinedAt(0))
+        val argSlot = VarSlot(argNames(1))
+        val argValue = rfaFacts.filter(p=>argSlot == p.s).map(_.v)
+        argValue.foreach{
+          ins =>
+            val defsites = ins.getDefSite
+            val loc = Center.getProcedureWithoutFailing(defsites.getProcedureSig).getProcedureBody.location(defsites.getCurrentLocUri)
+            //The found definition loc should be an assignment action
+            var bar:ActionLocation = loc.asInstanceOf[ActionLocation]
+            var as:AssignAction = bar.action.asInstanceOf[AssignAction]
+            //retrive right side value
+            var nameExp:NameExp = as.rhs.asInstanceOf[NameExp]
+            if(nameExp.name.name.equals(VUL_PARAM))
+            {
+              result += (node -> false)
+            }
+        }
+    }
+    result
+  }
+  
+  def getHTTPSNode(node : CGNode): Set[(String, CGCallNode)] = {
+    val result : MSet[(String, CGCallNode)] = msetEmpty
+    node match{
+      case invNode : CGCallNode =>
+        val calleeSet = invNode.getCalleeSet
+        calleeSet.foreach{
+          callee =>
+            val calleep = Center.getProcedureWithoutFailing(callee.callee)
+            val callees : MSet[JawaProcedure] = msetEmpty
+            val caller = Center.getProcedureWithoutFailing(invNode.getOwner)
+            val jumpLoc = caller.getProcedureBody.location(invNode.getLocIndex).asInstanceOf[JumpLocation]
+            val cj = jumpLoc.jump.asInstanceOf[CallJump]
+            if(calleep.getSignature == Center.UNKNOWN_PROCEDURE_SIG){
+              val calleeSignature = cj.getValueAnnotation("signature") match {
+                case Some(s) => s match {
+                  case ne : NameExp => ne.name.name
+                  case _ => ""
+                }
+                case None => throw new RuntimeException("cannot found annotation 'signature' from: " + cj)
+              }
+              callees ++= Center.getProcedureDeclarations(calleeSignature)
+            } else {
+              callees += calleep
+            }
+            callees.foreach{
+              callee =>
+                if(callee.getSignature.equals(API_SIG)){
+                  result += ((callee.getSignature, invNode))
+                }
+            }
+        }
+      case _ =>
+    }
+    result.toSet
+  }
+}


### PR DESCRIPTION
This plugin implemented https misuse detection (ALLOW_ALL_HOSTNAME_VERIFIER) utilizing amandroid's ability of _interprocedure_ reaching fact analysis (constant propagation), thus providing high accuracy.
